### PR TITLE
Add `isEmail` function

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -5,6 +5,11 @@
     "import": "{ Email }"
   },
   {
+    "name": "`isEmail`",
+    "path": "src/index.js",
+    "import": "{ isEmail }"
+  },
+  {
     "name": "`capitalize`",
     "path": "src/index.js",
     "import": "{ capitalize }"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Compare with [last published version](https://github.com/frontacles/frontacles/c
 
 ### Documentation
 
-- It is now more explicit in types that `Email.canParse` expects a `string` or a `Stringable` (from `any|Email` to `any|string|Email|Stringable`).
+- It is now more explicit in types that `Email.canParse` expects a `string` or a `Stringable` (changed from `any|Email` to `any|string|Email|Stringable`).
 - Rephrase email documentation.
 
 ### Under the hood

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,12 @@ Compare with [last published version](https://github.com/frontacles/frontacles/c
 ### Documentation
 
 - It is now more explicit in types that `Email.canParse` expects a `string` or a `Stringable` (from `any|Email` to `any|string|Email|Stringable`).
+- Rephrase email documentation.
 
 ### Under the hood
 
-- Centralize all benchmarks in [`./benchs`](./benchs)
-- Benchmark [`Email`](./benchs/url)
+- Centralize all benchmarks in [`./benchs`](./benchs).
+- Benchmark [`Email`](./benchs/url).
 
 ## v0.3.0 (2025-03-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 Compare with [last published version](https://github.com/frontacles/frontacles/compare/0.2.3...main).
 
+### New
+
+- Add [`isEmail`](./README.md#isemail) to validate emails.
+
+### Documentation
+
+- It is now more explicit in types that `Email.canParse` expects a `string` or a `Stringable` (from `any|Email` to `any|string|Email|Stringable`).
+
 ### Under the hood
 
 - Centralize all benchmarks in [`./benchs`](./benchs)

--- a/README.md
+++ b/README.md
@@ -122,7 +122,8 @@ isEmail('invalid@email.com:3000') // false
 > When using the `Email` class, you can still use `isEmail` if you want ultra-performance (e.g. your Node API validates tons of emails per seconds) because `isEmail` is 6✕ faster, at the cost of a bit less than 100 Bytes (compressed).
 >
 > The reason `isEmail` is faster is that it relies on a single RegExp while `Email.canParse` uses the browser built-in, which results in a bit more of computation, but with less code. For now, it’s not planned to use `isEmail` implementation in `Email.canParse` as it would increase its size by 50 Bytes.
-> Keep in mind that **`Email.canParse` is fast enough** for the 99% use cases.
+>
+> Keep in mind that **`Email.canParse` is fast enough** for the 99% use cases. Despite their implementation difference, both behave the same and pass the same tests.
 > </details>
 
 ### `Email`
@@ -178,7 +179,7 @@ console.log(email.toString()) // 'someone@newdomain.tld'
 
 Validate an email address with `Email.canParse`.
 
-Unlike most libraries using [RegExp to validate a string is an email](https://github.com/colinhacks/zod/blob/e2b9a5f9ac67d13ada61cd8e4b1385eb850c7592/src/types.ts#L648-L663) (which is prone to [bugs](https://github.com/colinhacks/zod/issues/3913)), Frontacles `Email` relies on built-in `URL` mechanisms as your browser, making it robust, and very likely RFC compliant. It passes [popular libraries test suites](./src/url/test-utils), and beyond.
+Unlike most libraries using [RegExp to validate a string is an email](https://github.com/colinhacks/zod/blob/e2b9a5f9ac67d13ada61cd8e4b1385eb850c7592/src/types.ts#L648-L663) (which is prone to [bugs](https://github.com/colinhacks/zod/issues/3913)), Frontacles `Email` relies on the built-in `URL` mechanisms, making it robust, and very likely RFC compliant. It passes [popular libraries test suites](./src/url/test-utils), and beyond.
 
 ```js
 Email.canParse('someone@domain.tld') // true

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ We love tiny bits (using brotli compression):
 | math | [`clamp`](#clamp) | 35 B |
 | math | [`round`](#round) | 38 B |
 | string | [`capitalize`](#capitalize) | 40 B |
-| url | [`Email`](#email) | 173 B |
 | url | [`isEmail`](#isemail) | 86 B |
+| url | [`Email`](#email) | 173 B |
 |  | **everything** | 328 B |
 
 ## Math utils

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ We love tiny bits (using brotli compression):
 | math | [`round`](#round) | 38 B |
 | string | [`capitalize`](#capitalize) | 40 B |
 | url | [`Email`](#email) | 173 B |
-|  | **everything** | 252 B |
+| url | [`isEmail`](#isemail) | 86 B |
+|  | **everything** | 328 B |
 
 ## Math utils
 
@@ -97,6 +98,21 @@ capitalize('صحراء') // 'صحراء' (Arabic)
 
 ## URL utils
 
+### `isEmail`
+
+Tells whether a string is a valid email.
+
+```js
+isEmail('someone@domain.tld') // true
+isEmail('invalid@email.com:3000') // false
+```
+
+> [!TIP]  
+> <details>
+> <summary>Should I use `isEmail` or `Email.canParse`?</summary>
+> To complete.
+> </details>
+
 ### `Email`
 
 A class to instantiate an `Email` object or validate email addresses.
@@ -128,7 +144,7 @@ console.log(`email: ${email}`) // 'email: someone@newdomain.tld'
 console.log(email.toString()) // 'someone@newdomain.tld'
 ```
 
-Validate an email address with `Email.canParse`. It passes the complete Zod test suites, and beyond.
+Validate an email address with `Email.canParse`. It passes [popular libraries test suites](./src/url/test-utils), and beyond.
 
 ```js
 Email.canParse('someone@domain.tld') // true

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ isEmail('invalid@email.com:3000') // false
 >
 > When using the `Email` class, you can still use `isEmail` if you want ultra-performance (e.g. your Node API validates tons of emails per seconds) because `isEmail` is 6✕ faster, at the cost of a bit less than 100 Bytes (compressed).
 >
-> The reason `isEmail` is faster is that it relies on a single RegExp while `Email.canParse` uses the browser built-in, which results in a bit more of computation, but with less code. For now, it’s not planned to use isEmail implementation in `Email.canParse` as it would increase its size by 50 Bytes.
+> The reason `isEmail` is faster is that it relies on a single RegExp while `Email.canParse` uses the browser built-in, which results in a bit more of computation, but with less code. For now, it’s not planned to use `isEmail` implementation in `Email.canParse` as it would increase its size by 50 Bytes.
 > Keep in mind that **`Email.canParse` is fast enough** for the 99% use cases.
 > </details>
 
@@ -130,11 +130,29 @@ A class to instantiate an `Email` object or validate email addresses. It extends
 
 Unlike most libraries using [RegExp to validate a string is an email](https://github.com/colinhacks/zod/blob/e2b9a5f9ac67d13ada61cd8e4b1385eb850c7592/src/types.ts#L648-L663) (which is prone to [bugs](https://github.com/colinhacks/zod/issues/3913)), Frontacles `Email` relies on built-in `URL` mechanisms as your browser, making it robust, and very likely RFC compliant.
 
+#### `Email.constructor`
+
 ```js
 import { Email } from 'frontacles/url/email'
 
 const email = new Email('someone@domain.tld')
 ```
+
+Trying to instantiate an Email with an invalid address will throw. This behaviour is similar to the [`URL` constructor](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL), since `Email` relies on it under the hood.
+
+```js
+new Email('double@at@sign.com') // ❌ throw TypeError
+```
+
+Another behaviour from `URL`: passing an `Email` object to the `Email` constructor or to `Email.canParse` is possible.
+
+```js
+const email = new Email('someone@domain.tld')
+const alsoEmail = new Email(email) // ✅ a new Email object!
+Email.canParse(email) // ✅ true
+```
+
+#### `.username` and `.hostname`
 
 Get or set the email username and hostname separately.
 
@@ -148,12 +166,16 @@ email.hostname = 'newdomain.tld' // ✅ domain migrated
 const { username, hostname } = new Email('someone@domain.tld')
 ```
 
-An `Email` object is converted to a string when used along another string, or by directly calling `toString`.
+#### `.toString`
+
+In a string context, an `Email` object is automatically converted to a string, or manually by calling the `toString` method.
 
 ```js
 console.log(`email: ${email}`) // 'email: someone@newdomain.tld'
 console.log(email.toString()) // 'someone@newdomain.tld'
 ```
+
+#### `Email.canParse`
 
 Validate an email address with `Email.canParse`. It passes [popular libraries test suites](./src/url/test-utils), and beyond.
 
@@ -162,19 +184,7 @@ Email.canParse('someone@domain.tld') // true
 Email.canParse('invalid@email.com:3000') // false
 ```
 
-Trying to instantiate an Email with an invalid address will throw. This behaviour is similar to the [`URL` constructor](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL), since `Email` relies on it under the hood.
-
-```js
-new Email('double@at@sign.com') // ❌ throw TypeError
-```
-
-Another behaviour from the `URL` class: you can pass an `Email` object to the `Email` constructor (or to `Email.canParse`, but it doesn’t really make sense).
-
-```js
-const email = new Email('someone@domain.tld')
-const alsoEmail = new Email(email) // ✅ a new Email object!
-Email.canParse(email) // ✅ true
-```
+If `canParse` is all you need from the `Email` class, consider using [isEmail](#isemail) instead.
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -108,9 +108,18 @@ isEmail('invalid@email.com:3000') // false
 ```
 
 > [!TIP]  
+> Should I use `isEmail` or `Email.canParse` to validate emails?
+> Short answer: use `isEmail`.
+> 
 > <details>
-> <summary>Should I use `isEmail` or `Email.canParse`?</summary>
-> To complete.
+> <summary>Nuanced answer</summary>
+>
+> - If you **only need to validate** email addresses, use `isEmail`.
+> - If you also need to be able to retrieve or update the email username or its hostname **independently**, use `Email`. There’s _probably_ no point in using the `Email` class otherwise. Tell use if you find any other interesting use case.
+>
+> If you need `Email` and if your concern is:
+> - JS footprint: it’s best you rely on `Email.canParse` instead of importing `isEmail`, which will result in a smaller JS footprint;
+> - ultra-performance: (e.g. your Node API validates tons of emails per seconds): use `isEmail` because it’s 6✕ faster. That being said, `Email.canParse` is still fast enough for 99% use cases.
 > </details>
 
 ### `Email`

--- a/README.md
+++ b/README.md
@@ -107,9 +107,10 @@ isEmail('invalid@email.com:3000') // false
 ```
 
 > [!TIP]  
-> Should I use `isEmail` or `Email.canParse` to validate emails?
+> Should I use `isEmail` or [`Email.canParse`](#emailcanparse) to validate emails?
+>
 > Short answer: use `isEmail`.
-> 
+>
 > <details>
 > <summary>Nuanced answer</summary>
 >
@@ -128,8 +129,6 @@ isEmail('invalid@email.com:3000') // false
 
 A class to instantiate an `Email` object or validate email addresses. It extends the [`URL` object](https://developer.mozilla.org/en-US/docs/Web/API/URL) and has similar predictable behaviors.
 
-Unlike most libraries using [RegExp to validate a string is an email](https://github.com/colinhacks/zod/blob/e2b9a5f9ac67d13ada61cd8e4b1385eb850c7592/src/types.ts#L648-L663) (which is prone to [bugs](https://github.com/colinhacks/zod/issues/3913)), Frontacles `Email` relies on built-in `URL` mechanisms as your browser, making it robust, and very likely RFC compliant.
-
 #### `Email.constructor`
 
 ```js
@@ -144,7 +143,7 @@ Trying to instantiate an Email with an invalid address will throw. This behaviou
 new Email('double@at@sign.com') // ❌ throw TypeError
 ```
 
-Another behaviour from `URL`: passing an `Email` object to the `Email` constructor or to `Email.canParse` is possible.
+Another behaviour from `URL`: passing an `Email` object to the `Email` constructor or to [`Email.canParse`](#emailcanparse) is possible.
 
 ```js
 const email = new Email('someone@domain.tld')
@@ -177,7 +176,9 @@ console.log(email.toString()) // 'someone@newdomain.tld'
 
 #### `Email.canParse`
 
-Validate an email address with `Email.canParse`. It passes [popular libraries test suites](./src/url/test-utils), and beyond.
+Validate an email address with `Email.canParse`.
+
+Unlike most libraries using [RegExp to validate a string is an email](https://github.com/colinhacks/zod/blob/e2b9a5f9ac67d13ada61cd8e4b1385eb850c7592/src/types.ts#L648-L663) (which is prone to [bugs](https://github.com/colinhacks/zod/issues/3913)), Frontacles `Email` relies on built-in `URL` mechanisms as your browser, making it robust, and very likely RFC compliant. It passes [popular libraries test suites](./src/url/test-utils), and beyond.
 
 ```js
 Email.canParse('someone@domain.tld') // true

--- a/README.md
+++ b/README.md
@@ -47,10 +47,9 @@ clamp(Infinity, 0, 10) // 10
 > [!NOTE]  
 > `clamp` mostly follows [`Math.clamp` TC39 proposal](https://github.com/tc39/proposal-math-clamp), except it doesn’t throw if you flip the order of the _min_ (2nd parameter) and _max_ (3rd parameter) numbers.
 
-
 ### `round`
 
-Round a number to the (optionally) provided precision.
+Round a number to the (optionally) provided decimal precision. The default precision is 0 (no decimal).
 
 ```js
 import { round } from 'frontacles/math'
@@ -67,7 +66,7 @@ round(687.3456, -1)  // 690
 round(687.3456, -2)  // 700
 ```
 
-Trying to round `Infinity` or to round a number to an _infinite_ precision is also possible:
+Using `Infinity` is also possible:
 
 ```js
 round(Infinity, -2) // Infinity
@@ -114,19 +113,22 @@ isEmail('invalid@email.com:3000') // false
 > <details>
 > <summary>Nuanced answer</summary>
 >
-> - If you **only need to validate** email addresses, use `isEmail`.
-> - If you also need to be able to retrieve or update the email username or its hostname **independently**, use `Email`. There’s _probably_ no point in using the `Email` class otherwise. Tell use if you find any other interesting use case.
+> Your use case:
 >
-> If you need `Email` and if your concern is:
-> - JS footprint: it’s best you rely on `Email.canParse` instead of importing `isEmail`, which will result in a smaller JS footprint;
-> - ultra-performance: (e.g. your Node API validates tons of emails per seconds): use `isEmail` because it’s 6✕ faster. That being said, `Email.canParse` is still fast enough for 99% use cases.
+> - If you **only need to validate** email addresses, use `isEmail`.
+> - If you also need to be able to get or set an email username or hostname **independently**, use `Email.canParse`.
+>
+> When using the `Email` class, you can still use `isEmail` if you want ultra-performance (e.g. your Node API validates tons of emails per seconds) because `isEmail` is 6✕ faster, at the cost of a bit less than 100 Bytes (compressed).
+>
+> The reason `isEmail` is faster is that it relies on a single RegExp while `Email.canParse` uses the browser built-in, which results in a bit more of computation, but with less code. For now, it’s not planned to use isEmail implementation in `Email.canParse` as it would increase its size by 50 Bytes.
+> Keep in mind that **`Email.canParse` is fast enough** for the 99% use cases.
 > </details>
 
 ### `Email`
 
-A class to instantiate an `Email` object or validate email addresses.
+A class to instantiate an `Email` object or validate email addresses. It extends the [`URL` object](https://developer.mozilla.org/en-US/docs/Web/API/URL) and has similar predictable behaviors.
 
-Unlike most libraries using [RegEx to validate a string is an email](https://github.com/colinhacks/zod/blob/e2b9a5f9ac67d13ada61cd8e4b1385eb850c7592/src/types.ts#L648-L663) (which is prone to [bugs](https://github.com/colinhacks/zod/issues/3913)), Frontacles `Email` relies on the same mechanism as your browser, making it robust, and very likely RFC compliant.
+Unlike most libraries using [RegExp to validate a string is an email](https://github.com/colinhacks/zod/blob/e2b9a5f9ac67d13ada61cd8e4b1385eb850c7592/src/types.ts#L648-L663) (which is prone to [bugs](https://github.com/colinhacks/zod/issues/3913)), Frontacles `Email` relies on built-in `URL` mechanisms as your browser, making it robust, and very likely RFC compliant.
 
 ```js
 import { Email } from 'frontacles/url/email'
@@ -134,7 +136,7 @@ import { Email } from 'frontacles/url/email'
 const email = new Email('someone@domain.tld')
 ```
 
-Get or set the username and the hostname separately.
+Get or set the email username and hostname separately.
 
 ```js
 email.username // 'someone'
@@ -170,9 +172,7 @@ Another behaviour from the `URL` class: you can pass an `Email` object to the `E
 
 ```js
 const email = new Email('someone@domain.tld')
-
 const alsoEmail = new Email(email) // ✅ a new Email object!
-
 Email.canParse(email) // ✅ true
 ```
 

--- a/src/url/email.js
+++ b/src/url/email.js
@@ -41,7 +41,7 @@ export class Email extends URL {
   /**
    * Whether or not an email address is parsable and valid.
    *
-   * @param {any|Email} address
+   * @param {any|string|Email} address
    */
   static canParse(address) {
     try {
@@ -58,6 +58,6 @@ export class Email extends URL {
  *
  * It uses WHATWG recommended RegExp: https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address
  *
- * @param {any} address
+ * @param {any|string|Email} address
  */
 export const isEmail = address => /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/.test(address)

--- a/src/url/email.js
+++ b/src/url/email.js
@@ -41,7 +41,7 @@ export class Email extends URL {
   /**
    * Whether or not an email address is parsable and valid.
    *
-   * @param {any|string|Email} address
+   * @param {any|string|Email|Stringable} address
    */
   static canParse(address) {
     try {
@@ -58,6 +58,11 @@ export class Email extends URL {
  *
  * It uses WHATWG recommended RegExp: https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address
  *
- * @param {any|string|Email} address
+ * @param {any|string|Stringable} address
  */
 export const isEmail = address => /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/.test(address)
+
+/**
+ * @typedef {Object} Stringable
+ * @property {function(): string} toString - The object as a string.
+ */

--- a/src/url/email.js
+++ b/src/url/email.js
@@ -17,6 +17,9 @@ export class Email extends URL {
   }
 
   /**
+   * The email address (`username@domain.tld`) as a string.
+   *
+   * (maintainer comment)
    * Replace the string representation of the top-level class (`URL`) to be an
    * email address instead of `ftp://username@domain.tld`. It is needed for
    * situation where type casting to string is involved (`console.log`…).

--- a/src/url/email.js
+++ b/src/url/email.js
@@ -58,4 +58,4 @@ export class Email extends URL {
  *
  * @param {string|any} address
  */
-export const isEmail = address => /^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/.test(address)
+export const isEmail = address => /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/.test(address)

--- a/src/url/email.js
+++ b/src/url/email.js
@@ -49,3 +49,13 @@ export class Email extends URL {
     }
   }
 }
+
+/**
+ * Whether or not an email address is parsable and valid.
+ *
+ * Use WHATWG recommended RegExp: https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address
+ * Downside: that’s a RegExp to maintain while `URL` is maintained by the browser.
+ *
+ * @param {string|any} address
+ */
+export const isEmail = address => /^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/.test(address)

--- a/src/url/email.js
+++ b/src/url/email.js
@@ -56,9 +56,8 @@ export class Email extends URL {
 /**
  * Whether or not an email address is parsable and valid.
  *
- * Use WHATWG recommended RegExp: https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address
- * Downside: that’s a RegExp to maintain while `URL` is maintained by the browser.
+ * It uses WHATWG recommended RegExp: https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address
  *
- * @param {string|any} address
+ * @param {any} address
  */
 export const isEmail = address => /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/.test(address)

--- a/src/url/email.test.js
+++ b/src/url/email.test.js
@@ -148,7 +148,7 @@ describe('url/isEmail', () => {
   // https://github.com/colinhacks/zod/issues/3913
   test('o&leary@example.com is valid', () =>
     expect(isEmail('o&leary@example.com')).toBeTruthy()
-)
+  )
 
   test('to parse without username', () => {
     /** @todo Should run in browser (https://vitest.dev/guide/browser/config.html). */

--- a/src/url/email.test.js
+++ b/src/url/email.test.js
@@ -5,7 +5,7 @@ import { invalidEmailsFromValibot, validEmailsFromValibot } from './test-utils/v
 // import { validateEmail } from './test-utils/dom-powered-email-validation'
 
 /**
- * The test suites for Email.parse and isEmail have the same expectations.
+ * @file Tests for `Email.parse` and `isEmail` have the same expectations.
  */
 
 describe('url/email', () => {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -17,15 +17,15 @@ export class Email extends URL {
 	/**
 	 * Whether or not an email address is parsable and valid.
 	 *
-	 * @param {any|Email} address
+	 * @param {any|string|Email} address
 	 */
-	static canParse(address: any | Email): boolean;
+	static canParse(address: any | string | Email): boolean;
 	/**
 	 * @param {string|Email} address An email address like `someone@domain.tld`.
 	 */
 	constructor(address: string | Email);
 	#private;
 }
-export function isEmail(address: string | any): boolean;
+export function isEmail(address: any | string | Email): boolean;
 
 export {};

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -17,15 +17,21 @@ export class Email extends URL {
 	/**
 	 * Whether or not an email address is parsable and valid.
 	 *
-	 * @param {any|string|Email} address
+	 * @param {any|string|Email|Stringable} address
 	 */
-	static canParse(address: any | string | Email): boolean;
+	static canParse(address: any | string | Email | Stringable): boolean;
 	/**
 	 * @param {string|Email} address An email address like `someone@domain.tld`.
 	 */
 	constructor(address: string | Email);
 	#private;
 }
-export function isEmail(address: any | string | Email): boolean;
+export function isEmail(address: any | string | Stringable): boolean;
+export type Stringable = {
+	/**
+	 * - The object as a string.
+	 */
+	toString: () => string;
+};
 
 export {};

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -26,5 +26,6 @@ export class Email extends URL {
 	constructor(address: string | Email);
 	#private;
 }
+export function isEmail(address: string | any): boolean;
 
 export {};

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,13 +1,27 @@
 import { expectError, expectType } from 'tsd'
-import { clamp, Email, round } from '.'
+import { clamp, Email, isEmail, round } from '.'
 
 /**
- * Test url/email
+ * Test math/*
+ */
+
+expectType<number>(clamp(0, 1, 2))
+expectType<number>(round(Math.PI, 3))
+
+/**
+ * Test url/isEmail
+ */
+
+const myEmail = new Email('someone@domain.tld')
+expectType<boolean>(isEmail('someone@domain.tld'))
+expectType<boolean>(isEmail(myEmail))
+
+/**
+ * Test url/Email
  */
 
 // Correct instantiations
 
-const myEmail = new Email('someone@domain.tld')
 expectType<Email>(myEmail)
 expectType<string>(myEmail.username)
 expectType<string>(myEmail.hostname)
@@ -27,11 +41,3 @@ expectType<boolean>(Email.canParse(new Date()))
 
 expectType<string>(myEmail.toString())
 expectType<string>(`${myEmail}`)
-
-
-/**
- * Test math
- */
-
-expectType<number>(clamp(0, 1, 2))
-expectType<number>(round(Math.PI, 3))


### PR DESCRIPTION
## Checklist

<!-- Thanks for your contribution! -->

- [x] I’m aware of the [contributing guidelines](https://github.com/frontacles/frontacles/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/frontacles/frontacles/blob/main/CODE_OF_CONDUCT.md).
- [x] The code I add comes with:
  - [x] tests
  - [x] types (`npm run types` to generate them from JSDoc comments)
  - [x] [documentation](https://github.com/frontacles/frontacles/blob/main/README.md)
  - [x] [changelog](https://github.com/frontacles/frontacles/blob/main/CHANGELOG.md)
  - [x] [`size-limit` config](https://github.com/frontacles/frontacles/blob/main/.size-limit.json)
  - [ ] [benchmarks](https://github.com/frontacles/frontacles/blob/main/CONTRIBUTING.md#benchmarks)

---

Created following #35.

Could be useful for people wanting only URL validation, without any benefit brought by the `Email` class, since `isEmail` is smaller and faster. If someone use `Email`, then it’s not worth using `isEmail` since they don’t share any code, and probably shouldn’t. `Email` doesn’t need RegExp maintenance since it only relies on browser built-ins.